### PR TITLE
fix(assign-rfc-reviewer):Avoid re-requesting reviews

### DIFF
--- a/.github/actions/assign-rfc-reviewer/index.js
+++ b/.github/actions/assign-rfc-reviewer/index.js
@@ -51,7 +51,19 @@ async function lookForKeywords(octokit, keywords, rfcFileContent) {
   const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
   const pull_number = github.context.payload.pull_request.number;
 
+  const currentReviewersResponse = await octokit.request(
+    "GET /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers",
+    {
+      owner,
+      repo,
+      pull_number,
+    }
+  );
+  const currentTeamReviewerSlugs = currentReviewersResponse.data.teams.map((t) => t.slug)
+
   keywords.teams.forEach(async (team) => {
+    if (currentTeamReviewerSlugs.includes(team.slug)) return;
+
     const keywordFound = team.keywords.some(
       (keyword) => rfcFileContent.indexOf(keyword) > -1
     );


### PR DESCRIPTION
When this action re-requests review from a team, it's PR Review status is set to "Pending", even if it was "Commented"/"Approved"/"Requested Changes" before.
The PR Review status shouldn't be automatically changed.

Also, there can be false-positive cases for the keywords search.
Now, when a false-positive is detected by a team, they can just make a "Comment Review" in the PR.
By doing this, the slack bot "Github Scheduled Reminders" shouldn't notify the team about these false-positives.